### PR TITLE
unexpected token error fixed

### DIFF
--- a/backend/src/controllers/userControllers.js
+++ b/backend/src/controllers/userControllers.js
@@ -115,7 +115,9 @@ const add = (req, res) => {
 	models.user
 		.insert(user)
 		.then(([result]) => {
-			res.location(`/users/${result.insertId}`).sendStatus(201);
+			res
+				.location(`/users/${result.insertId}`)
+				.json({ message: "User created", id: result.insertId, user: user });
 		})
 		.catch((err) => {
 			console.error(err);


### PR DESCRIPTION
Correction de l'erreur "unexpected token" renvoyée par le front.
Il fallait renvoyer des données valides en json. Avant il envoyait juste un statut 201 (created) mais le client ne pouvait pas le lire car il n'était pas transformé en json.
![Addcontroller](https://github.com/user-attachments/assets/17a62cc5-658d-43e5-8c0b-51027655c842)

Maintenant au submit le serveur renvoie ça :
![ResponseServer](https://github.com/user-attachments/assets/f95e3832-b5cc-4958-b380-49cf3355536f)

